### PR TITLE
Fix pages listing in course-type pages

### DIFF
--- a/layouts/course/section.html
+++ b/layouts/course/section.html
@@ -20,7 +20,7 @@
         <h3>chapters</h3>
         <ul>
             {{ range ( where .Sections "Type" "course_chapter" ) }}
-            <li><a href="{{ .Permalink }}"> {{ .Params.title }} </a></li>
+            <li><a href="#{{ replace .Params.title " " "-" }}"> {{ .Params.title }} </a></li>
             {{ end }}
         </ul>
     </nav>
@@ -33,7 +33,6 @@
         <hr>
         <!-- chapter title -->
         <div class="tiny-padding">
-            <h2 id="{{ replace .Params.title " " "-" }}" class="no-margin"> {{ .Params.title }} </h2>
             <!-- Course duration -->
             <!-- <span data-font="dimmed small">Duration: min s </span> -->
             <p>{{ .Description | markdownify }}</p>
@@ -41,6 +40,7 @@
             <!-- Video list -->
             <ol class="collection">
               {{ range ( where .Pages "Type" "course_chapter" ) }}
+                <h2 id="{{ replace .Params.title " " "-" }}" class="no-margin"> {{ .Params.title }} </h2>
                 {{ range (sort ( where .RegularPages "Type" "video" ) "Date") }}
                 <li class="item">
                     {{ if (isset .Params "videoid") }}

--- a/layouts/course/section.html
+++ b/layouts/course/section.html
@@ -20,7 +20,7 @@
         <h3>chapters</h3>
         <ul>
             {{ range ( where .Sections "Type" "course_chapter" ) }}
-            <li><a href="#{{ replace .Params.title " " "-" }}"> {{ .Params.title }} </a></li>
+            <li><a href="{{ .Permalink }}"> {{ .Params.title }} </a></li>
             {{ end }}
         </ul>
     </nav>
@@ -40,7 +40,8 @@
 
             <!-- Video list -->
             <ol class="collection">
-                {{ range (sort ( where .Pages "Type" "video" ) "Date") }}
+              {{ range ( where .Pages "Type" "course_chapter" ) }}
+                {{ range (sort ( where .RegularPages "Type" "video" ) "Date") }}
                 <li class="item">
                     {{ if (isset .Params "videoid") }}
                     <a href="{{ .URL }}">{{ .Title }}</a>
@@ -62,6 +63,7 @@
                     <!-- <span data-font="dimmed">()</span> -->
                 </li>
                 {{ end }}
+              {{ end }}
             </ol>
         </div>
     </div>


### PR DESCRIPTION
Started working on fixing the youtube series pages (chapter-type pages).

_Note_: reason why

```
{{ range (sort ( where .Pages "Type" "video" ) "Date") }}
```

doesn't work is because `.Pages` lists only **first-level** (i.e. pages that are at the same folder level as the chapter-type page -  `_index.html`) pages. The fix is simple, just nest two `range`s, one over `.Pages` and the inner over`.RegularPages` of type video.

I'll skip making this a draft as maybe you want to push changes immediately instead of waiting for the other fixes like adding video duration etc.

And yeah, I also fixed the link pointing to the chapter list as it was broken... unless... that wasn't what it was supposed to do?!

Closes #133 