### PR TITLE
Fix text-align on chapters

### DIFF
--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -1,1 +1,4 @@
-<link rel="stylesheet" href="/css/fix-learn.css">
+{{ $postCSS_options := (dict "targetPath" "docs_styles.css" "outputStyle" "compressed" )}}
+{{ $stylesheet := resources.Get "scss/docs/docs.scss" | resources.ToCSS $postCSS_options | postCSS }}
+
+<link rel="stylesheet" href="{{ $stylesheet.Permalink }}">

--- a/resources/scss/docs/docs.scss
+++ b/resources/scss/docs/docs.scss
@@ -1,0 +1,2 @@
+// modules
+@import './modules/chapter';

--- a/resources/scss/docs/modules/_chapter.scss
+++ b/resources/scss/docs/modules/_chapter.scss
@@ -1,0 +1,5 @@
+#chapter {
+  p {
+    text-align: left;
+  }
+}

--- a/resources/scss/modules/_card.scss
+++ b/resources/scss/modules/_card.scss
@@ -21,7 +21,7 @@
     position: relative;
     overflow: hidden;
 
-    @include bg-centered
+    @include bg-centered;
 
     &.outline {
         @include card-outline;


### PR DESCRIPTION
closes #163 

I think this is what you meant by left-aligning the text? Or do you want to make the `chapter=true` sections to be identical to `chapter=false`?
![image](https://user-images.githubusercontent.com/18503860/74341572-4cd67d80-4deb-11ea-9d9b-b6ec76169467.png)
