### PR TITLE
Make tutorial sub-sub category pages display a menu

### DIFF
--- a/layouts/partials/components/nav-tutorial.html
+++ b/layouts/partials/components/nav-tutorial.html
@@ -19,11 +19,18 @@
 
 {{ $currentPage := . }}
 {{ $sections := "" }}
+{{ $isIntermediatePage := false }}
 
 {{ if .IsPage }}
+{{/* "Leaf" page such as `/tutorial/godot/audio/volume-slider/`. */}}
 {{ $sections = $currentPage.Parent.Parent.Sections }}
-{{ else }}
+{{ else if .Sections }}
+{{/* Root section page. */}}
 {{ $sections = .Sections }}
+{{ else }}
+{{/* Intermediate page such as `/tutorial/godot/audio/`. */}}
+{{ $isIntermediatePage = true }}
+{{ $sections = $currentPage.Parent.Sections }}
 {{ end }}
 
 <nav class="nav-tutorial" role="navigation">
@@ -31,7 +38,13 @@
     <hr />
     <ul class="list">
         {{ range $sections }}
-        {{ $isActiveSection := eq $currentPage.Parent .CurrentSection }}
+
+        {{ $isActiveSection := false }}
+        {{ if $isIntermediatePage }}
+        {{ $isActiveSection = eq $currentPage .CurrentSection }}
+        {{ else }}
+        {{ $isActiveSection = eq $currentPage.Parent .CurrentSection }}
+        {{ end }}
         <li>
             <div class="menu-link -section" style="justify-content: start" onclick="navTutorialToggleSection(this)">
                 {{ with .Params.icon }}


### PR DESCRIPTION
This is a better user experience than displaying "Menu" with nothing below it.

The current section is automatically unfolded and marked as active.

This can probably be done better (not sure how exactly). Let me know if you have any suggestions :slightly_smiling_face: 

This closes #215.

## Preview

![Tutorial sub-sub category page](https://user-images.githubusercontent.com/180032/98423147-09fdb980-208e-11eb-9327-46db1dbdc402.png)
