### PR TITLE
Use lazy loading for autoplaying videos

### DIFF
--- a/content/news/2017/12/godot-3-course-character-controller/index.md
+++ b/content/news/2017/12/godot-3-course-character-controller/index.md
@@ -22,10 +22,7 @@ Use the coupon code "early" to **get 20% off** while the course is in early acce
 
 In this series, you'll learn how to create a fairly robust **character controller**: we're covering input, walk and run speed, handling collisions, adding a bump animation when the character hits something... with a lot of techniques exposed along the way.
 
-<video width="854" height="480" autoplay loop>
-  <source src="character-controller-demo-small.mp4" type="video/mp4">
-Your browser does not support the video tag.
-</video>
+{{< video "character-controller-demo-small.mp4" "854" >}}
 
 I took care to not only make the code work, but to go beyond the basics. As you'll see the controller is **reusable**. That's something you won't find in the majority of online courses: using object-oriented design, both the AI and playable characters can share the same movement code.
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,6 +11,36 @@
     <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
     {{ $postCSS_options := (dict "targetPath" "style.css" "outputStyle" "compressed" )}}
     {{ $stylesheet := resources.Get "scss/gdquest.scss" | resources.ToCSS $postCSS_options | postCSS }}
+    <script>
+        // Use lazy loading for autoplaying videos.
+        // This is not required for Chrome as it performs lazy loading for such videos
+        // automatically, but other browsers like Firefox don't do this yet.
+        document.addEventListener("DOMContentLoaded", function() {
+            const lazyVideos = [].slice.call(document.querySelectorAll("video[data-lazy]"));
+            if ("IntersectionObserver" in window) {
+                const lazyVideoObserver = new IntersectionObserver(function(entries, observer) {
+                    entries.forEach(function(video) {
+                        if (video.isIntersecting) {
+                            for (let source in video.target.children) {
+                                const videoSource = video.target.children[source];
+                                if (typeof videoSource.tagName === "string" && videoSource.tagName === "SOURCE") {
+                                    videoSource.src = videoSource.dataset.src;
+                                }
+                            }
+
+                            video.target.load();
+                            lazyVideoObserver.unobserve(video.target);
+                        }
+                    });
+                });
+
+                lazyVideos.forEach(function(lazyVideo) {
+                    lazyVideoObserver.observe(lazyVideo);
+                });
+            }
+        });
+    </script>
+
 
     <link rel="stylesheet" href="{{ $stylesheet.Permalink }}">
     {{ partial "meta" . }}

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -1,4 +1,5 @@
-<video controls autoplay muted loop playsinline width="{{ with .Get 1 }}{{ . }}px{{ else }}720px{{ end }}">
-    <source src="{{ .Get 0 }}" type="video/mp4">
+<video controls autoplay muted loop playsinline width="{{ with .Get 1 }}{{ . }}px{{ else }}720px{{ end }}" data-lazy>
+    {{/* Use `data-src` instead of `src` to support lazy loading (see head.html). */}}
+    <source data-src="{{ .Get 0 }}" type="video/mp4">
     Your browser does not support the video tag.
 </video>


### PR DESCRIPTION
This improves page loading performance by only loading videos once they are made visible by scrolling.

Chrome already does this by default according to https://web.dev/lazy-loading-video/, but this enables a similar feature for all browsers.

This also replaces a `video` tag that didn't use the video shortcode.

**Note:** This PR doesn't implement a fallback for Internet Explorer 11. Let me know if I should add one.

This closes #212.