### PR TITLE
Display language selection in the mobile navigation bar

### DIFF
--- a/assets/scss/components/language-dropdown.scss
+++ b/assets/scss/components/language-dropdown.scss
@@ -35,6 +35,8 @@
             > a {
                 color: white;
                 width: 100%;
+                // Make links easier to target with mouse/touch.
+                padding: 10px 0;
             }
             > a:hover {
                 color: $color-gdquest-yellow;
@@ -45,6 +47,34 @@
 
 @include tablet {
     .language-dropdown {
+        margin: 10px 0;
+
+        // Display on mobile is toggled using the navbar (see `nav-main.scss`).
         display: none;
+
+        &:hover {
+            > .list > li,
+            > .list:focus-within > li,
+            > .list:hover {
+                display: unset;
+            }
+        }
+
+        span {
+            // Highlight the currently active language.
+            color: $color-gdquest-yellow;
+        }
+
+        > .list {
+            position: unset;
+            display: inline;
+            width: 100%;
+
+        }
+
+        > .list li a {
+            // Make links easier to target with mouse/touch.
+            padding: 10px;
+        }
     }
 }

--- a/assets/scss/components/nav-main.scss
+++ b/assets/scss/components/nav-main.scss
@@ -124,6 +124,15 @@
       > .links.-social > a:first-child {
         margin: unset;
       }
+
+      > .language-dropdown {
+        display: inline-block;
+        width: 100%;
+
+        > .list > li {
+          display: inline;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This cloese #231.

## Preview

### Desktop

I added some vertical padding to each language link to make them easier to click:

![image](https://user-images.githubusercontent.com/180032/101184239-c7111080-3650-11eb-9e9c-d7077d102fca.png)

### Mobile

New language dropdown for mobile:

![image](https://user-images.githubusercontent.com/180032/101184167-b1035000-3650-11eb-9cba-2d381d4225a4.png)

The menu is designed to behave well with large amounts of language options:

![image](https://user-images.githubusercontent.com/180032/101184339-e740cf80-3650-11eb-87f0-78ced41b1926.png)
