### PR TITLE
Tell Welcomments what the custom reply link classname is

### DIFF
--- a/layouts/partials/welcomments/comments.html
+++ b/layouts/partials/welcomments/comments.html
@@ -41,7 +41,12 @@
   }}
 </div>
 
-<script defer id="welcomments__script" src="https://cdn.welcomments.io/welcomments.js" type="text/javascript"></script>
+<script defer
+  id="welcomments__script"
+  src="https://cdn.welcomments.io/welcomments.js"
+  type="text/javascript"
+  data-comment-reply-link-classname="button-link"
+></script>
 <script type="text/javascript">
   welcomments = {
     apiUrl: {{ $apiUrl }},


### PR DESCRIPTION
This fixes the issue where Welcomments falls back on [the hosted comment reply page](https://welcomments.io/api/websites/JkcjXa5tVOPkFEPsZfhQ/comments/01F2H48GCJ4QQDGCD2WP2KXSZ2/reply) when clicking on the "Reply to John Doe" button.