### PR TITLE
Fix Getting Started with the Godot Game Engine in 2021 youtube url

### DIFF
--- a/content/tutorial/godot/learning-paths/beginner/index.md
+++ b/content/tutorial/godot/learning-paths/beginner/index.md
@@ -114,7 +114,7 @@ It's motivating to start that way.
 
 But we also included a few resources that go through some theory to help you better understand how game engines and programming work.
 
-[Getting Started with Godot in 2021]({{< ref "/docs/power-sequencer/getting-started/_index.md" >}}) is a free course that covers everything you need to get started with Godot. By the end, you'll create complete 2D and 3D games from start to finish.
+[Getting Started with Godot in 2021](//https://www.youtube.com/watch?v=42HKCFf5Lf4&list=PLhqJJNjsQ7KEcm-iYJ2a8UCRN62bTneKa) is a free course that covers everything you need to get started with Godot. By the end, you'll create complete 2D and 3D games from start to finish.
 
 ![3D game banner](img/3d-game-banner.png)
 

--- a/content/tutorial/godot/learning-paths/beginner/index.md
+++ b/content/tutorial/godot/learning-paths/beginner/index.md
@@ -114,7 +114,7 @@ It's motivating to start that way.
 
 But we also included a few resources that go through some theory to help you better understand how game engines and programming work.
 
-[Getting Started with Godot in 2021](//https://www.youtube.com/watch?v=42HKCFf5Lf4&list=PLhqJJNjsQ7KEcm-iYJ2a8UCRN62bTneKa) is a free course that covers everything you need to get started with Godot. By the end, you'll create complete 2D and 3D games from start to finish.
+[Getting Started with Godot in 2021](//www.youtube.com/watch?v=42HKCFf5Lf4&list=PLhqJJNjsQ7KEcm-iYJ2a8UCRN62bTneKa) is a free course that covers everything you need to get started with Godot. By the end, you'll create complete 2D and 3D games from start to finish.
 
 ![3D game banner](img/3d-game-banner.png)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
This PR fix an URL. "Getting Started with Godot in 2021" hyperlink is pointing to a power sequencer tutorial, this PR corrects it to redirect the user to the playlist in the GDQuest channel.


**Does this PR introduce a breaking change?**
No.


## New feature or change ##


**What is the current behavior?** 
"Getting Started with Godot in 2021" hyperlink is pointing to a power sequencer tutorial.


**What is the new behavior?**
"Getting Started with Godot in 2021" hyperlink will point to "Getting Started with Godot in 2021" playlist in the GDQuest channel.


**Other information**
