### PR TITLE
fix(GDScript Styleguide): Update links in References

### DIFF
--- a/content/docs/guidelines/best-practices/godot-gdscript/_index.md
+++ b/content/docs/guidelines/best-practices/godot-gdscript/_index.md
@@ -421,8 +421,8 @@ In some cases, we use Godot's `addons` directory. This is mostly for files that 
 
 In this style guide, we drew inspiration from the work of the Python community, some functional programming principles, and the official GDScript documentation:
 
-1. [GDScript Style Guide](//docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html)
-1. [Static typing in GDScript](//docs.godotengine.org/en/latest/getting_started/scripting/gdscript/static_typing.html)
+1. [GDScript Style Guide](//docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_styleguide.html)
+1. [Static typing in GDScript](//docs.godotengine.org/en/stable/getting_started/scripting/gdscript/static_typing.html)
 1. [Docs writing guidelines](//docs.godotengine.org/en/latest/community/contributing/docs_writing_guidelines.html)
 1. [Boundaries - A talk by Gary Bernhardt from SCNA 2012](//www.destroyallsoftware.com/talks/boundaries) & [Functional Core, Imperative Shell](//www.destroyallsoftware.com/screencasts/catalog/functional-core-imperative-shell)
 1. [The Clean Architecture in Python](//www.youtube.com/watch?v=DJtef410XaM)


### PR DESCRIPTION
Two links (gdscript_styleguide and static_typing) were going to 404 pages in the latest Godot docs, since the getting started tutorials were removed in /latest. This PR updates those links to the /stable pages of the godot docs.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [x] You updated the docs or changelog.

**What kind of change does this PR introduce?**

Changes the link location of two links at the bottom of the GDScript codestyle page.

**Does this PR introduce a breaking change?**

Nope

## New feature or change ##

**What is the current behavior?** 

Links to 404 pages that were removed in Godot docs /latest:
- https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html
- https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/static_typing.html

**What is the new behavior?**

Links to the intended pages on Godot docs /stable
- https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_styleguide.html
- https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/static_typing.html

**Other information**
